### PR TITLE
Update nowcast.R

### DIFF
--- a/R/nowcast.R
+++ b/R/nowcast.R
@@ -164,7 +164,7 @@ nowcast <- function(formula, data, r = NULL, q = NULL, p = NULL, method = 'EM', 
     if(!is.matrix(blocks)){blocks <- as.matrix(blocks)}
     
     # determine the number of blocks
-    blocks <- as.matrix(blocks) # variables should be rows, columns the blocks
+    blocks <- as.matrix(blocks,ncol=ncol(blocks)) # variables should be rows, columns the blocks
     n_blocks <- dim(blocks)[2]
     
     x <- ts(model.frame(formula, data, na.action = NULL), start = start(data), frequency = frequency(data))


### PR DESCRIPTION
should solve issue #9

added ncol=ncol(blocks) otherwise matrices with only one column (single factor) become vectors and the subsequent code produces an error when dim(blocks)[2] is called